### PR TITLE
feat: 模板导出与组件库增强

### DIFF
--- a/backend/src/routes/templates.ts
+++ b/backend/src/routes/templates.ts
@@ -6,8 +6,16 @@ import { prisma } from '../database';
 import { renderTemplate, composePage } from '../services/templateRenderer';
 import { searchTemplates } from '../services/templateIndex';
 import { getMemoryTemplateBySlug } from '../services/templateMemory';
+import { exportTemplateAsZip } from '../services/templateExporter';
+import { createTemplateVersion, rollbackTemplateVersion } from '../services/templateVersioning';
 
 const router = express.Router();
+
+function getRequestId(req: express.Request) {
+  const header = req.headers['x-request-id'];
+  if (Array.isArray(header)) return header[0];
+  return (req as any).requestId || (req as any).id || (typeof header === 'string' ? header : undefined);
+}
 
 // Multer for ZIP upload (in-memory or temp disk). Here we use memory to keep stub simple.
 const upload = multer({
@@ -17,35 +25,101 @@ const upload = multer({
 
 // POST /api/templates/import-zip
 router.post('/import-zip', upload.single('file'), async (req, res) => {
+  const requestId = getRequestId(req);
   try {
     if (!req.file) {
       res.status(400);
       return res.json({ success: false, error: 'ZIP file is required' });
     }
     const userId = (req as any).user?.id || 'u_demo';
-    const result = await importZipToTemplates(req.file.buffer, userId);
+    const result = await importZipToTemplates(req.file.buffer, userId, { requestId });
     return res.json({ success: true, ...result });
   } catch (err: any) {
-    logger.error('import-zip error', err);
-    res.status(500).json({ success: false, error: err?.message || 'Server error' });
+    logger.error('import-zip error', { requestId, error: err?.message });
+    const status = err?.status || 500;
+    res.status(status).json({ success: false, error: err?.message || 'Server error' });
   }
 });
 
 // GET /api/templates/search
 router.get('/search', async (req, res) => {
+  const requestId = getRequestId(req);
   try {
     const { query, type, engine } = req.query as any;
     const tags = (req.query.tags as any) ? ([] as string[]).concat(req.query.tags as any) : undefined;
     const r = await searchTemplates({ query, type, engine, tags, limit: Number(req.query.limit)||20, offset: Number(req.query.offset)||0 });
     return res.json(r);
   } catch (err: any) {
-    logger.error('templates search error', err);
+    logger.error('templates search error', { requestId, error: err?.message });
     res.status(500).json({ success: false, error: err?.message || 'Server error' });
+  }
+});
+
+router.get('/:id/export', async (req, res) => {
+  const requestId = getRequestId(req);
+  const templateId = req.params.id;
+  try {
+    const { buffer, filename } = await exportTemplateAsZip(templateId, { requestId });
+    res.setHeader('Content-Type', 'application/zip');
+    res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+    return res.send(buffer);
+  } catch (err: any) {
+    const status = err?.status || 500;
+    const message = err?.message || 'Export failed';
+    if (status === 404) {
+      logger.warn('template export not found', { requestId, templateId, error: message });
+    } else {
+      logger.error('template export error', { requestId, templateId, error: message });
+    }
+    if (!res.headersSent) {
+      res.status(status).json({ success: false, error: message });
+    }
+  }
+});
+
+router.post('/:id/versions', async (req, res) => {
+  const requestId = getRequestId(req);
+  const templateId = req.params.id;
+  const { version } = req.body || {};
+  if (!version) return res.status(400).json({ success: false, error: 'version is required' });
+  try {
+    const result = await createTemplateVersion(templateId, version, { requestId });
+    return res.json({ success: true, ...result });
+  } catch (err: any) {
+    const status = err?.status || 500;
+    const message = err?.message || 'Failed to create version';
+    if (status === 409) {
+      logger.warn('template version conflict', { requestId, templateId, version, error: message });
+    } else {
+      logger.error('template version error', { requestId, templateId, version, error: message });
+    }
+    res.status(status).json({ success: false, error: message });
+  }
+});
+
+router.post('/:id/rollback', async (req, res) => {
+  const requestId = getRequestId(req);
+  const templateId = req.params.id;
+  const { version } = req.body || {};
+  if (!version) return res.status(400).json({ success: false, error: 'version is required' });
+  try {
+    const result = await rollbackTemplateVersion(templateId, version, { requestId });
+    return res.json({ success: true, ...result });
+  } catch (err: any) {
+    const status = err?.status || 500;
+    const message = err?.message || 'Failed to rollback version';
+    if (status === 404) {
+      logger.warn('template rollback missing', { requestId, templateId, version, error: message });
+    } else {
+      logger.error('template rollback error', { requestId, templateId, version, error: message });
+    }
+    res.status(status).json({ success: false, error: message });
   }
 });
 
 // GET /api/templates/:slug
 router.get('/:slug', async (req, res) => {
+  const requestId = getRequestId(req);
   try {
     const { slug } = req.params;
     try {
@@ -58,36 +132,46 @@ router.get('/:slug', async (req, res) => {
       return res.status(404).json({ success: false, error: `Template not found: ${slug}` });
     }
   } catch (err: any) {
-    logger.error('template get error', err);
+    logger.error('template get error', { requestId, error: err?.message });
     res.status(500).json({ success: false, error: err?.message || 'Server error' });
   }
 });
 
 // POST /api/templates/render
 router.post('/render', async (req, res) => {
+  const requestId = getRequestId(req);
   try {
     const { slug, data, theme, engine } = req.body || {};
     if (!slug) return res.status(400).json({ success: false, error: 'slug is required' });
-    const result = await renderTemplate({ slug, data, theme, engine });
+    const result = await renderTemplate({ slug, data, theme, engine }, { requestId });
     res.json(result);
   } catch (err: any) {
-    logger.error('template render error', err);
     const msg = String(err?.message || 'Server error');
-    const code = /Schema validation failed/i.test(msg) ? 422 : 500;
+    const code = /Schema validation failed/i.test(msg) ? 422 : err?.status || 500;
+    if (code === 422) {
+      logger.warn('template render validation', { requestId, error: msg });
+    } else {
+      logger.error('template render error', { requestId, error: msg });
+    }
     res.status(code).json({ success: false, error: msg });
   }
 });
 
 // POST /api/templates/compose
 router.post('/compose', async (req, res) => {
+  const requestId = getRequestId(req);
   try {
     const body = req.body || {};
-    const result = await composePage(body);
+    const result = await composePage(body, { requestId });
     res.json(result);
   } catch (err: any) {
-    logger.error('template compose error', err);
     const msg = String(err?.message || 'Server error');
-    const code = /Schema validation failed/i.test(msg) ? 422 : 500;
+    const code = /Schema validation failed/i.test(msg) ? 422 : err?.status || 500;
+    if (code === 422) {
+      logger.warn('template compose validation', { requestId, error: msg });
+    } else {
+      logger.error('template compose error', { requestId, error: msg });
+    }
     res.status(code).json({ success: false, error: msg });
   }
 });

--- a/backend/src/services/templateExporter.ts
+++ b/backend/src/services/templateExporter.ts
@@ -1,0 +1,102 @@
+import path from 'path';
+import fs from 'fs/promises';
+import AdmZip from 'adm-zip';
+import * as cheerio from 'cheerio';
+import { prisma } from '../database';
+import { logger } from '../utils/logger';
+import { ensureRelative } from '../utils/file';
+
+const UPLOADS_ROOT = process.env.UPLOADS_ROOT || process.env.UPLOAD_PATH || './uploads';
+
+export async function exportTemplateAsZip(identifier: string, opts?: { requestId?: string }) {
+  const { requestId } = opts || {};
+  const startedAt = Date.now();
+  const logMeta = { identifier, requestId };
+  logger.info('template.export.start', logMeta);
+
+  const tpl = await prisma.template.findFirst({
+    where: { OR: [{ id: identifier }, { slug: identifier }] },
+  });
+  if (!tpl) {
+    const err = new Error(`Template not found: ${identifier}`);
+    (err as any).status = 404;
+    throw err;
+  }
+
+  const zip = new AdmZip();
+  const engine = (tpl.engine || 'plain').toLowerCase();
+  const baseName = tpl.slug || tpl.id;
+
+  if (engine === 'hbs') {
+    zip.addFile('template.hbs', Buffer.from(tpl.code || '', 'utf8'));
+  } else if (engine === 'react') {
+    zip.addFile('template.tsx', Buffer.from(tpl.code || '', 'utf8'));
+  } else {
+    zip.addFile('index.html', Buffer.from(tpl.code || '', 'utf8'));
+  }
+
+  if (tpl.previewHtml) {
+    zip.addFile('preview.html', Buffer.from(String(tpl.previewHtml), 'utf8'));
+  }
+
+  const meta = {
+    id: tpl.id,
+    slug: tpl.slug,
+    name: tpl.name,
+    description: tpl.description || '',
+    version: tpl.version,
+    type: tpl.type,
+    engine: tpl.engine,
+    tags: tpl.tags || [],
+    schema: tpl.schemaJson || null,
+    tokens: tpl.tokensJson || null,
+    exportedAt: new Date().toISOString(),
+  };
+  zip.addFile('meta.json', Buffer.from(JSON.stringify(meta, null, 2), 'utf8'));
+
+  const assetPaths = collectAssetPaths(tpl.code || '', tpl.previewHtml || '');
+  const writtenAssets: string[] = [];
+  for (const asset of assetPaths) {
+    const normalized = asset.split('?')[0].split('#')[0];
+    if (!normalized.startsWith('/uploads/')) continue;
+    try {
+      const rel = ensureRelative(normalized.replace(/^\/uploads\//, ''));
+      const abs = path.resolve(UPLOADS_ROOT, rel);
+      const data = await fs.readFile(abs);
+      const entryPath = path.posix.join('assets', rel.replace(/\\/g, '/'));
+      zip.addFile(entryPath, data);
+      writtenAssets.push(rel);
+    } catch (err: any) {
+      logger.warn('template.export.assetMissing', { ...logMeta, asset, error: err?.message });
+    }
+  }
+
+  const buffer = zip.toBuffer();
+  const filename = `${baseName || 'template'}-${tpl.version || '1.0.0'}.zip`;
+  logger.info('template.export.success', { ...logMeta, assets: writtenAssets.length, durationMs: Date.now() - startedAt });
+
+  return { buffer, filename, assetCount: writtenAssets.length };
+}
+
+function collectAssetPaths(...sources: string[]) {
+  const set = new Set<string>();
+  for (const src of sources) {
+    if (!src) continue;
+    try {
+      const $ = cheerio.load(src);
+      $('[src], [href]').each((_, el) => {
+        const $el = $(el);
+        const val = $el.attr('src') || $el.attr('href') || '';
+        if (!val) return;
+        if (/^https?:/i.test(val) || /^data:/i.test(val)) return;
+        set.add(val);
+      });
+    } catch {}
+    const matches = String(src).match(/['"`]?\(?(\/uploads\/[^'"`\s)]+)/gi) || [];
+    matches.forEach(m => {
+      const cleaned = m.replace(/^['"`\(]/, '');
+      if (cleaned.startsWith('/uploads/')) set.add(cleaned);
+    });
+  }
+  return Array.from(set);
+}

--- a/backend/src/services/templateVersioning.ts
+++ b/backend/src/services/templateVersioning.ts
@@ -1,0 +1,146 @@
+import { prisma } from '../database';
+import { logger } from '../utils/logger';
+
+interface OperationOptions {
+  requestId?: string;
+}
+
+interface SemverParts {
+  major: number;
+  minor: number;
+  patch: number;
+  prerelease?: string;
+}
+
+function parseSemver(input: string): SemverParts | null {
+  const version = String(input || '').trim();
+  const match = version.match(/^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/);
+  if (!match) return null;
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    prerelease: match[4],
+  };
+}
+
+function compareSemver(a: string, b: string) {
+  const pa = parseSemver(a);
+  const pb = parseSemver(b);
+  if (!pa || !pb) return 0;
+  if (pa.major !== pb.major) return pa.major - pb.major;
+  if (pa.minor !== pb.minor) return pa.minor - pb.minor;
+  if (pa.patch !== pb.patch) return pa.patch - pb.patch;
+  if (pa.prerelease === pb.prerelease) return 0;
+  if (!pa.prerelease) return 1;
+  if (!pb.prerelease) return -1;
+  return pa.prerelease.localeCompare(pb.prerelease);
+}
+
+async function resolveTemplate(client: any, identifier: string) {
+  const tpl = await client.template.findFirst({
+    where: { OR: [{ id: identifier }, { slug: identifier }] },
+  });
+  if (!tpl) {
+    const err = new Error(`Template not found: ${identifier}`);
+    (err as any).status = 404;
+    throw err;
+  }
+  return tpl;
+}
+
+export async function createTemplateVersion(identifier: string, version: string, opts: OperationOptions = {}) {
+  const { requestId } = opts;
+  const parsed = parseSemver(version);
+  if (!parsed) {
+    const err = new Error('Invalid semver string');
+    (err as any).status = 400;
+    throw err;
+  }
+
+  return prisma.$transaction(async (tx) => {
+    const tpl = await resolveTemplate(tx, identifier);
+    const existing = await tx.templateVersion.findUnique({
+      where: { templateId_version: { templateId: tpl.id, version } },
+    });
+    if (existing) {
+      const err = new Error('Version already exists');
+      (err as any).status = 409;
+      throw err;
+    }
+
+    const comparison = compareSemver(version, tpl.version || '0.0.0');
+    if (comparison <= 0) {
+      const err = new Error('Version must be greater than current');
+      (err as any).status = 409;
+      throw err;
+    }
+
+    const snapshot = await tx.templateVersion.create({
+      data: {
+        templateId: tpl.id,
+        version,
+        code: tpl.code,
+        schemaJson: tpl.schemaJson as any,
+      },
+    });
+
+    const updated = await tx.template.update({
+      where: { id: tpl.id },
+      data: { version },
+    });
+
+    logger.info('template.version.created', { requestId, templateId: tpl.id, version });
+    return { template: updated, snapshot };
+  });
+}
+
+export async function rollbackTemplateVersion(identifier: string, targetVersion: string, opts: OperationOptions = {}) {
+  const { requestId } = opts;
+  const parsed = parseSemver(targetVersion);
+  if (!parsed) {
+    const err = new Error('Invalid semver string');
+    (err as any).status = 400;
+    throw err;
+  }
+
+  return prisma.$transaction(async (tx) => {
+    const tpl = await resolveTemplate(tx, identifier);
+    const target = await tx.templateVersion.findUnique({
+      where: { templateId_version: { templateId: tpl.id, version: targetVersion } },
+    });
+    if (!target) {
+      const err = new Error(`Version not found: ${targetVersion}`);
+      (err as any).status = 404;
+      throw err;
+    }
+
+    if (tpl.version && tpl.version !== target.version) {
+      const currentExists = await tx.templateVersion.findUnique({
+        where: { templateId_version: { templateId: tpl.id, version: tpl.version } },
+      });
+      if (!currentExists) {
+        await tx.templateVersion.create({
+          data: {
+            templateId: tpl.id,
+            version: tpl.version,
+            code: tpl.code,
+            schemaJson: tpl.schemaJson as any,
+          },
+        });
+      }
+    }
+
+    const updated = await tx.template.update({
+      where: { id: tpl.id },
+      data: {
+        code: target.code,
+        schemaJson: target.schemaJson as any,
+        version: target.version,
+      },
+    });
+
+    logger.info('template.version.rollback', { requestId, templateId: tpl.id, version: target.version });
+    return { template: updated };
+  });
+}

--- a/docs/templates/manifest-schema-examples.md
+++ b/docs/templates/manifest-schema-examples.md
@@ -1,0 +1,140 @@
+# 静态模板包结构与配置示例
+
+为了便于后端自动识别页面、组件和主题资源，静态 ZIP 包需要携带清晰的 `manifest.json`、`schema.json` 与 AI 辅助信息。以下示例展示了推荐的目录结构、字段含义及编写规范。
+
+## 目录结构建议
+
+```
+landing-page.zip
+├─ manifest.json          # 入口声明与元信息
+├─ schema.json            # 页面或组件的参数结构（可选）
+├─ ai-hints.json          # AI 生成/推荐提示（可选）
+├─ index.html             # 页面入口或组件示例
+├─ partials/
+│  ├─ header.html
+│  └─ footer.html
+└─ assets/
+   ├─ styles.css
+   └─ hero.png
+```
+
+- **入口 HTML**：页面类模板需提供完整的 `index.html`，组件类可提供片段或示例包装页。
+- **partials/**：可选，用于拆分 header/footer 等常用块，Importer 会尝试参数化并注册为组件。
+- **assets/**：存放引用的 CSS/JS/图片资源，导入后会被重写为 `/uploads/u_{userId}/{importId}/**`。
+
+## manifest.json 示例
+
+```json
+{
+  "slug": "startup-landing",
+  "name": "创业着陆页",
+  "description": "适合 SaaS/创业公司的三屏落地页",
+  "type": "page",
+  "engine": "hbs",
+  "version": "1.0.0",
+  "entry": "index.html",
+  "tags": ["landing", "startup", "saas"],
+  "components": [
+    { "slug": "site-header", "path": "partials/header.html" },
+    { "slug": "pricing-table", "path": "partials/pricing.html" }
+  ],
+  "assets": [
+    "assets/styles.css",
+    "assets/hero.png"
+  ],
+  "schema": "./schema.json",
+  "aiHints": "./ai-hints.json"
+}
+```
+
+### 字段说明
+
+- **slug**：模板唯一标识，Importer 会检测冲突并自动追加短 ID。
+- **type**：`page` / `component` / `theme`，用于前端筛选。
+- **engine**：`plain` / `hbs` / `react`，决定渲染方式与是否参数化。
+- **components**：仅对页面模板生效，指向可拆分的片段文件。
+- **assets**：静态资源相对路径，导出 ZIP 时会打包到 `assets/` 目录。
+- **schema**、**aiHints**：可选路径，指向同级 JSON 文件。
+
+## schema.json 示例
+
+以下示例采用 JSON Schema（Draft-07）描述页面参数，Importer 会用于表单生成与运行时校验：
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "hero": {
+      "type": "object",
+      "title": "英雄模块",
+      "properties": {
+        "title": { "type": "string", "title": "主标题" },
+        "subtitle": { "type": "string", "title": "副标题" },
+        "cta": {
+          "type": "object",
+          "title": "按钮",
+          "properties": {
+            "text": { "type": "string" },
+            "href": { "type": "string" }
+          },
+          "required": ["text"]
+        }
+      },
+      "required": ["title"]
+    },
+    "pricing": {
+      "type": "array",
+      "title": "价格方案",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "price": { "type": "string" },
+          "features": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        },
+        "required": ["name", "price"]
+      }
+    }
+  }
+}
+```
+
+## ai-hints.json 示例
+
+`TemplateAIHints` 用于指导 AI 在生成或组合页面时的语义提示：
+
+```json
+{
+  "summary": "适合展示 B2B SaaS 产品卖点的三屏页面",
+  "recommendedUseCases": ["SaaS", "企业官网"],
+  "keywords": ["SaaS", "Landing", "Startup"],
+  "sections": {
+    "hero": {
+      "description": "首屏强调价值主张，配合 CTA",
+      "example": "让团队 10 分钟上线营销页"
+    },
+    "pricing": {
+      "description": "展示 3 款套餐并强调差异点",
+      "required": true
+    }
+  },
+  "prompts": [
+    "请围绕产品效率优势撰写英雄模块文案",
+    "根据三种用户类型给出价格方案"
+  ]
+}
+```
+
+## 编写建议
+
+1. **命名规范**：`slug` 建议使用小写中划线（kebab-case），便于 URL 复用。
+2. **版本管理**：发布新版本时更新 `version` 字段并使用导出的 ZIP 作为备份，可与版本 API 协同。
+3. **Schema 粒度**：尽量拆分为 `object` + `array` 的层级结构，字段命名与组件 Handlebars 变量保持一致。
+4. **AI 提示**：`aiHints` 中的 `summary`、`sections`、`prompts` 将用于提示词拼接，避免出现敏感信息或真实客户数据。
+5. **资源引用**：HTML 内引用静态资源请使用相对路径（如 `assets/style.css`），Importer 会统一重写为 `/uploads/...` 前缀。
+
+按照上述约定整理 ZIP 包，可显著提升导入成功率、组件参数化准确性，以及前后端联调体验。

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import { DeploymentManagement } from './pages/DeploymentManagement';
 import { TokenStats } from './pages/TokenStats';
 import TemplateLibrary from './pages/TemplateLibrary';
 import UploadZip from './pages/UploadZip';
+import ComponentsLibrary from './pages/ComponentsLibrary';
 
 // Import new components
 import { DashboardSidebar } from './components/DashboardSidebar';
@@ -75,6 +76,8 @@ export default function App() {
         return <TokenStats />;
       case 'templates':
         return <TemplateLibrary />;
+      case 'components':
+        return <ComponentsLibrary />;
       case 'uploadZip':
         return <UploadZip />;
       default:

--- a/frontend/src/components/DashboardSidebar.tsx
+++ b/frontend/src/components/DashboardSidebar.tsx
@@ -20,7 +20,8 @@ import {
   Crown,
   ChevronRight,
   ChevronLeft,
-  Menu
+  Menu,
+  Layers
 } from 'lucide-react';
 
 const navigation = [
@@ -59,6 +60,12 @@ const navigation = [
     route: 'templates' as Route,
     icon: Code,
     description: '浏览与检索模板'
+  },
+  {
+    name: '组件库',
+    route: 'components' as Route,
+    icon: Layers,
+    description: '浏览与筛选组件'
   },
   {
     name: 'ZIP 导入',

--- a/frontend/src/lib/router.ts
+++ b/frontend/src/lib/router.ts
@@ -1,16 +1,17 @@
 import { create } from 'zustand';
 
-export type Route = 
-  | 'home' 
-  | 'login' 
-  | 'register' 
-  | 'dashboard' 
-  | 'editor' 
-  | 'settings' 
-  | 'websites' 
+export type Route =
+  | 'home'
+  | 'login'
+  | 'register'
+  | 'dashboard'
+  | 'editor'
+  | 'settings'
+  | 'websites'
   | 'deploy'
   | 'tokens'
   | 'templates'
+  | 'components'
   | 'uploadZip';
 
 interface RouterState {
@@ -33,6 +34,7 @@ export const useRouter = create<RouterState>((set) => ({
       deploy: '/deployments',
       tokens: '/tokens',
       templates: '/templates',
+      components: '/components',
       uploadZip: '/upload-zip'
     };
     
@@ -59,6 +61,7 @@ const initializeRouter = () => {
     '/deployments': 'deploy',
     '/tokens': 'tokens',
     '/templates': 'templates',
+    '/components': 'components',
     '/upload-zip': 'uploadZip'
   };
   

--- a/frontend/src/utils/templateDownload.ts
+++ b/frontend/src/utils/templateDownload.ts
@@ -1,0 +1,13 @@
+import { templateSDK } from '@/services/templateSDK';
+
+export async function downloadTemplateZip(templateId: string, slug: string) {
+  const blob = await templateSDK.export(templateId);
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = `${slug || 'template'}.zip`;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  setTimeout(() => URL.revokeObjectURL(url), 2000);
+}

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -138,3 +138,34 @@ export interface DailyUsage {
     cost: number;
   }>;
 }
+
+export type TemplateType = 'page' | 'component' | 'theme';
+export type TemplateEngine = 'plain' | 'hbs' | 'react';
+
+export interface TemplateAIHintField {
+  description?: string;
+  example?: string;
+  required?: boolean;
+}
+
+export interface TemplateAIHints {
+  summary?: string;
+  recommendedUseCases?: string[];
+  keywords?: string[];
+  sections?: Record<string, TemplateAIHintField>;
+  prompts?: string[];
+}
+
+export interface TemplateManifest {
+  slug: string;
+  name: string;
+  version: string;
+  type: TemplateType;
+  engine: TemplateEngine;
+  description?: string;
+  entry?: string;
+  tags?: string[];
+  schema?: Record<string, any> | null;
+  aiHints?: TemplateAIHints;
+  assets?: string[];
+}

--- a/test-import-manifest.js
+++ b/test-import-manifest.js
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+
+const AdmZip = require('adm-zip');
+
+async function main() {
+  const baseUrl = process.env.TEST_API_BASE || 'http://localhost:3001/api/templates';
+  console.log(`[info] Using API base: ${baseUrl}`);
+
+  const sampleHtml = `<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <title>示例落地页</title>
+    <link rel="stylesheet" href="assets/style.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <h1>欢迎来到示例站点</h1>
+    </header>
+    <section class="hero">
+      <h2>英雄模块</h2>
+      <p>这是一个用于测试组合的英雄模块。</p>
+    </section>
+    <section class="pricing">
+      <div class="plan">基础版</div>
+      <div class="plan">专业版</div>
+    </section>
+    <footer class="site-footer">版权所有</footer>
+    <script src="assets/app.js"></script>
+  </body>
+</html>`;
+
+  const zip = new AdmZip();
+  zip.addFile('index.html', Buffer.from(sampleHtml, 'utf8'));
+  zip.addFile('assets/style.css', Buffer.from('body{font-family:sans-serif;} .hero{padding:40px;background:#f5f5f5;}', 'utf8'));
+  zip.addFile('assets/app.js', Buffer.from('console.log("hello from sample");', 'utf8'));
+  const buffer = zip.toBuffer();
+
+  const form = new FormData();
+  form.append('file', new Blob([buffer], { type: 'application/zip' }), 'sample.zip');
+
+  console.log('[step] POST /import-zip');
+  const importRes = await fetch(`${baseUrl}/import-zip`, { method: 'POST', body: form });
+  const importJson = await importRes.json();
+  if (!importRes.ok || !importJson.success) {
+    throw new Error(`导入失败: ${importRes.status} ${importJson.error || ''}`);
+  }
+  const pages = importJson.pages || [];
+  const components = importJson.components || [];
+  if (!pages.length) throw new Error('导入未返回任何页面模板');
+  if (!components.length) throw new Error('导入未识别任何组件模板');
+  console.log(`[info] 导入成功，pages=${pages.length}, components=${components.length}`);
+
+  const pageSlug = pages[0];
+  const componentSlug = components[0];
+
+  console.log('[step] GET /:slug');
+  const tplRes = await fetch(`${baseUrl}/${pageSlug}`);
+  if (!tplRes.ok) throw new Error(`获取模板失败: ${tplRes.status}`);
+  const tplJson = await tplRes.json();
+  const templateId = tplJson.id;
+  if (!templateId) throw new Error('模板记录缺少 id 字段');
+
+  console.log('[step] GET /search?type=component');
+  const searchRes = await fetch(`${baseUrl}/search?type=component&query=${encodeURIComponent(componentSlug)}`);
+  if (!searchRes.ok) throw new Error(`搜索组件失败: ${searchRes.status}`);
+  const searchJson = await searchRes.json();
+  if (!Array.isArray(searchJson.items) || !searchJson.items.length) throw new Error('搜索结果为空');
+
+  console.log('[step] POST /render');
+  const renderRes = await fetch(`${baseUrl}/render`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ slug: pageSlug })
+  });
+  const renderJson = await renderRes.json();
+  if (!renderRes.ok || !renderJson.html) throw new Error('模板渲染失败');
+
+  console.log('[step] POST /compose');
+  const composeRes = await fetch(`${baseUrl}/compose`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      page: { slug: pageSlug },
+      components: [{ slot: componentSlug, slug: componentSlug, data: {} }]
+    })
+  });
+  const composeJson = await composeRes.json();
+  if (!composeRes.ok || !composeJson.html) throw new Error('组合页面失败');
+
+  console.log('[step] GET /:id/export');
+  const exportRes = await fetch(`${baseUrl}/${templateId}/export`);
+  if (!exportRes.ok) throw new Error(`导出模板失败: ${exportRes.status}`);
+  const contentType = exportRes.headers.get('content-type') || '';
+  if (!contentType.includes('zip')) throw new Error(`导出内容类型异常: ${contentType}`);
+  const exportBuffer = Buffer.from(await exportRes.arrayBuffer());
+  if (exportBuffer.length === 0) throw new Error('导出文件为空');
+
+  console.log('\n✅ 所有接口检查通过');
+  console.log(`- 导入模板: ${pageSlug}`);
+  console.log(`- 组件示例: ${componentSlug}`);
+  console.log(`- 导出 ZIP 大小: ${exportBuffer.length} 字节`);
+}
+
+main().catch((err) => {
+  console.error(`\n❌ 测试失败: ${err.message}`);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- 新增模板导出与版本管理服务，模板路由输出请求级日志并暴露 ZIP 导出、版本创建、回滚接口
- 丰富 ZIP 导入日志与资源过滤，并补充模板 Manifest/AI hints 共享类型与使用文档
- 更新模板 SDK 与库页面，新增组件库视图及编辑器中的组件排序、表单化配置与实时导出
- 提供导入/搜索/渲染/组合/导出串联的冒烟脚本，便于回归验证

## Testing
- npm run build *(失败：历史代码缺少 React/类型声明导致 TypeScript 报错)*
- npm run lint *(失败：项目仍使用 .eslintrc 旧格式，缺少 eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c93fe8ddf08324af8d4a3823a15e81